### PR TITLE
Refactor tagline click behavior and anchor header name

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,15 +4,7 @@
       <img src="/images/IsaacZais-132020.jpg" alt="Isaac Lee Zais" class="rounded" />
     </div>
     <h1 class="grid_item_header" id="project_title">{{site.title}}</h1>
-    <h2
-      class="grid_item_subheader"
-      id="project_tagline"
-      data-base-subtitle="Software Engineer"
-      data-second-subtitle="Hobbyist Cryptographer"
-      data-third-subtitle="Dungeon Master"
-    >
-      Software Engineer
-    </h2>
+    <h2 class="grid_item_subheader" id="project_tagline">Software Engineer</h2>
   </div>
 </header>
 
@@ -24,23 +16,21 @@
       return;
     }
 
-    const baseSubtitle = tagline.dataset.baseSubtitle;
-    const secondSubtitle = tagline.dataset.secondSubtitle;
-    const thirdSubtitle = tagline.dataset.thirdSubtitle;
+    const subtitles = [
+      "Software Engineer",
+      "Hobbyist Cryptographer",
+      "Dungeon Master",
+    ];
+
     let clickCount = 0;
 
     const updateSubtitle = () => {
-      if (clickCount >= 10) {
-        tagline.textContent = `${baseSubtitle} | ${secondSubtitle} | ${thirdSubtitle}`;
-        return;
-      }
+      const subtitleCount = Math.min(
+        subtitles.length,
+        Math.floor(clickCount / 5) + 1,
+      );
 
-      if (clickCount >= 5) {
-        tagline.textContent = `${baseSubtitle} | ${secondSubtitle}`;
-        return;
-      }
-
-      tagline.textContent = baseSubtitle;
+      tagline.textContent = subtitles.slice(0, subtitleCount).join(" | ");
     };
 
     tagline.addEventListener("click", () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -28,7 +28,7 @@
 
 .grid_container {
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: auto auto;
     grid-template-areas: 
         "image header"
@@ -46,7 +46,7 @@
     
 .grid_item_header {
     justify-self: stretch;
-    align-self: end;
+    align-self: start;
     grid-area: header;    
     grid-column-start: 2;
     grid-column-end: 3;


### PR DESCRIPTION
### Motivation
- Make the clickable job-title behavior data-driven so new titles can be added without changing branching logic. 
- Ensure the site title (name) remains aligned with the profile image and does not shift as the subtitle text grows. 

### Description
- Replace multiple `data-*` subtitle attributes with a `subtitles` array and render N titles based on `Math.floor(clickCount / 5) + 1`, adding one title every 5 clicks in `project_tagline` JavaScript. 
- Simplify the tagline markup to a single element `#project_tagline` and compute displayed text from the `subtitles` array. 
- Adjust header layout CSS to use `grid-template-columns: auto minmax(0, 1fr);` and change `.grid_item_header` to `align-self: start` so the name stays top-aligned and does not move when subtitles expand. 

### Testing
- Verified the file diffs for `_includes/header.html` and `styles/main.css` with `git diff` to confirm the intended changes (succeeded). 
- Attempted to run a local Jekyll preview with `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, which failed because the `jekyll` executable is not available in the current bundle environment (failed). 
- Attempted `bundle install` to install dependencies for a local preview, but it failed due to remote gem fetch errors from `rubygems.org` (HTTP 403) in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7359ee3508326bf995ca5393c2a7b)