### PR TITLE
Tighten header spacing and inline collapsible chevrons

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -33,7 +33,7 @@
     grid-template-areas: 
         "image header"
         "image subheader";
-    grid-gap: 10px 10px;
+    grid-gap: 4px 10px;
 }
 
 .grid_item_image {
@@ -124,12 +124,12 @@ hr {
 #project_title {
     justify-self: start;
     line-height: 1.15;
-    margin-bottom: 6px;
+    margin-bottom: 0;
 }
 
 #project_tagline {
     justify-self: start;
-    line-height: 1.25;
+    line-height: 1.15;
 }
 
 .content_block {
@@ -141,6 +141,8 @@ hr {
 .content_block summary {
     list-style: none;
     cursor: pointer;
+    display: flex;
+    align-items: flex-start;
 }
 
 .content_block summary::-webkit-details-marker {
@@ -150,10 +152,16 @@ hr {
 .content_block summary::before {
     content: "▸";
     margin-right: 8px;
+    line-height: 1.15;
+    flex: 0 0 auto;
 }
 
 .content_block[open] summary::before {
     content: "▾";
+}
+
+.content_block summary > * {
+    flex: 1 1 auto;
 }
 
 .content_block ul,


### PR DESCRIPTION
### Motivation
- Condense vertical spacing between the hero name and rotating subtitle to create a cleaner, tighter header layout.
- Keep the details/disclosure chevron on the same line as company or university titles so collapsible sections read as a single line.

### Description
- Reduced header vertical gap by changing `.grid_container` `grid-gap` to `4px 10px` and removing the bottom margin on `#project_title` while trimming `#project_tagline` line-height in `styles/main.css`.
- Converted `.content_block summary` to a flex container with `display: flex` and `align-items: flex-start` so the summary text and chevron align horizontally.
- Adjusted the custom chevron by adding `line-height` and `flex: 0 0 auto` to `summary::before` and made summary children flexible via `.content_block summary > * { flex: 1 1 auto; }`.

### Testing
- Served the site locally and captured a full-page screenshot via Playwright to validate the updated header spacing and inline summary chevrons, which visually confirmed the changes.
- Ran `bundle exec jekyll build` which failed in this environment because the `jekyll` executable is not installed (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7520afe748326b3e57fe65b129687)