### PR TITLE
Update subtitle click titles and align employment summary rows

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,20 @@
       "Hobbyist Cryptographer",
       "Dungeon Master",
       "Football Enthusiast",
-      "Wisconsin Badgers Diehard",
+      "Wisconsin Badger",
+      "Packers Co-Owner",
+      "Rogue-like Enthusiast",
+      "That's It",
+      "No Seriously That's It",
+      "You can stop clicking now",
+      "Seriously, there isn't any more to find here",
+      "...",
+      "...",
+      "...",
+      "Persistent, aren't ya?",
+      "Well you can stop now, there's nothing here",
+      "...",
+      "It's not quite time yet",
     ];
 
     let clickCount = 0;

--- a/styles/main.css
+++ b/styles/main.css
@@ -130,6 +130,9 @@ hr {
 #project_tagline {
     justify-self: start;
     line-height: 1.15;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 .content_block {
@@ -142,7 +145,7 @@ hr {
     list-style: none;
     cursor: pointer;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
 }
 
 .content_block summary::-webkit-details-marker {
@@ -162,6 +165,10 @@ hr {
 
 .content_block summary > * {
     flex: 1 1 auto;
+}
+
+.content_block summary .subtitle_line {
+    margin: 0;
 }
 
 .content_block ul,


### PR DESCRIPTION
### Motivation
- Expand and correct the rotating/clickable subtitle sequence shown in the header and prevent accidental text selection while clicking the subtitle. 
- Fix layout issues where the collapse chevron sits on a separate line from the company/institution text so the summary row looks horizontally aligned.

### Description
- Updated `_includes/header.html` to rename `"Wisconsin Badgers Diehard"` to `"Wisconsin Badger"` and append the requested additional subtitle entries to the `subtitles` array. 
- Updated `styles/main.css` to make `#project_tagline` non-selectable and show a pointer cursor by adding `cursor: pointer`, `user-select: none`, and `-webkit-user-select: none`.
- Adjusted the collapsible summary styling in `styles/main.css` by changing `.content_block summary` to `align-items: center` and adding `.content_block summary .subtitle_line { margin: 0; }` so the chevron and text align horizontally.

### Testing
- Attempted `bundle exec jekyll build`, which could not run because the `jekyll` executable is not available in this environment (build failed). 
- Attempted `bundle install`, which failed due to upstream RubyGems `403 Forbidden` responses so dependencies could not be installed.
- Attempted an automated Playwright screenshot of the served site, but the browser process crashed with a `SIGSEGV` in the container, so visual verification via screenshot was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8b4e83a148326b47af0638f8abc24)