### PR TITLE
Add eerie final-subtitle visual state to header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,11 @@
 <header class="inner" id="extended_header">
   <div class="grid_container">
     <div class="grid_item_image image-cropper">
-      <img src="/images/IsaacZais-132020.jpg" alt="Isaac Lee Zais" class="rounded" />
+      <img src="/images/IsaacZais-132020.jpg" alt="Isaac Lee Zais" class="rounded" id="project_portrait" />
     </div>
     <h1 class="grid_item_header" id="project_title">{{site.title}}</h1>
     <h2 class="grid_item_subheader" id="project_tagline">Software Engineer</h2>
+    <p class="grid_item_whisper" id="watching_text" aria-hidden="true">Eye am watching</p>
   </div>
 </header>
 
@@ -37,6 +38,9 @@
       "It's not quite time yet",
     ];
 
+    const portrait = document.getElementById("project_portrait");
+    const watchingText = document.getElementById("watching_text");
+
     let clickCount = 0;
 
     const updateSubtitle = () => {
@@ -46,6 +50,17 @@
       );
 
       tagline.textContent = subtitles.slice(0, subtitleCount).join(" | ");
+
+      const hasReachedFinalSubtitle = subtitleCount === subtitles.length;
+      tagline.classList.toggle("tagline-threat", hasReachedFinalSubtitle);
+
+      if (portrait) {
+        portrait.classList.toggle("portrait-inverted", hasReachedFinalSubtitle);
+      }
+
+      if (watchingText) {
+        watchingText.classList.toggle("watching-text-visible", hasReachedFinalSubtitle);
+      }
     };
 
     tagline.addEventListener("click", () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -135,6 +135,34 @@ hr {
     -webkit-user-select: none;
 }
 
+#project_tagline.tagline-threat {
+    color: #b30000;
+}
+
+#project_portrait.portrait-inverted {
+    filter: invert(1);
+}
+
+.grid_item_whisper {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+    align-self: end;
+    margin: 0;
+    opacity: 0;
+    color: #770000;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    text-shadow: none;
+    transition: opacity 0.3s ease-in-out;
+    pointer-events: none;
+    user-select: none;
+}
+
+.grid_item_whisper.watching-text-visible {
+    opacity: 0.18;
+}
+
 .content_block {
     margin: 10px 0;
     border-bottom: 1px solid #aaaaaa;
@@ -222,6 +250,13 @@ hr {
     #project_tagline {
         justify-self: center;
         text-align: center;
+    }
+
+    .grid_item_whisper {
+        grid-column: 1;
+        grid-row: 3;
+        justify-self: center;
+        margin-top: 4px;
     }
 
 }


### PR DESCRIPTION
### Motivation
- Provide a subtle, final-state visual cue when the header subtitle sequence is fully expanded to create a dramatic effect. 
- Change the portrait and subtitle appearance only at the final subtitle to avoid affecting normal header behavior. 
- Add a very subtle whisper line reading `Eye am watching` that only becomes visible in the final state.

### Description
- Added an `id="project_portrait"` to the header image and inserted a hidden whisper line `<p class="grid_item_whisper" id="watching_text">Eye am watching</p>` in `_includes/header.html` so both can be toggled. 
- Extended the subtitle click handler in `_includes/header.html` to detect when the subtitle sequence reaches its last entry and toggle classes `tagline-threat`, `portrait-inverted`, and `watching-text-visible`. 
- Added CSS in `styles/main.css` to color the final subtitle red (`#b30000`), invert the portrait via `filter: invert(1)`, and reveal the whisper text at low opacity with responsive positioning for mobile. 

### Testing
- Attempted `bundle exec jekyll build` to validate the rendered site, which failed because the `jekyll` executable is not available in the environment. (failed) 
- Attempted `bundle install` to install dependencies, which failed due to RubyGems network errors returning `403 Forbidden` in this environment. (failed) 
- Served the repo with `python3 -m http.server 4000` and attempted a Playwright-driven click/screenshot flow to reach the final subtitle state, but the browser automation timed out when locating the element because the site was not Jekyll-built in this environment. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c456ae888326b9b5faf4feec95c4)